### PR TITLE
add “—timestamp” option to add secure timestamp

### DIFF
--- a/SymbolNameAutocomplete.xcodeproj/project.pbxproj
+++ b/SymbolNameAutocomplete.xcodeproj/project.pbxproj
@@ -575,6 +575,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.5.4;
+				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.cyan-stivy.sketchPlugin.symbol-name-autocomplete";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
[Resolving Common Notarization Issues \| Apple Developer Documentation](https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution/resolving_common_notarization_issues)